### PR TITLE
fixed double render error for /users/sign_out

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,10 +14,10 @@ class UsersController < ApplicationController
   # GET /users/1.json
   def show
     redirect_to root_url
-    if User.exists?(params[:id].to_i) && params[:id].to_i == current_user.id 
-    else
-      redirect_to "/users"
-    end 
+    # if User.exists?(params[:id].to_i) && params[:id].to_i == current_user.id 
+    # else
+    #   redirect_to "/users"
+    # end 
   end
 
   # GET /users/new


### PR DESCRIPTION
Fixed bug that caused app to break when a signed in user went to "/users/sign_out"

Was receiving the following error message:

"Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return"."

