### PR TITLE
had a dash instead of an equals sign for setting stock_symbol to be equal to it's value but up-cased

### DIFF
--- a/app/assets/javascripts/getPriceAndConfirm.js
+++ b/app/assets/javascripts/getPriceAndConfirm.js
@@ -156,7 +156,7 @@ function secondIexCall() {
     $("#getPriceForm").submit(function (event) {
         event.preventDefault();
         stockSymbol = document.getElementById("stock_symbol").value
-        stockSymbol - stockSymbol.toUpperCase()
+        stockSymbol = stockSymbol.toUpperCase()
         quantity = document.getElementById("numberOfShares").value
         quantity = quantity.toUpperCase()
         //   var data = $(this).serializeArray();


### PR DESCRIPTION
stockSymbol - stockSymbol.toUpperCase()

changed to:

stockSymbol = stockSymbol.toUpperCase()