### PR TITLE
says 'share' instead of 'shares' when qty is 1 for confirm text

### DIFF
--- a/app/assets/javascripts/getPriceAndConfirm.js
+++ b/app/assets/javascripts/getPriceAndConfirm.js
@@ -99,8 +99,14 @@ $(document).on('turbolinks:load', function () {
                 if (fullPrice < hiddenAccountBalance) {
                     fullPrice = fullPrice.toFixed(2)
 
-
-                    document.getElementById("stockQuote").innerText = `${convertToUsCurrency.format(fullPrice)} is the cost for ${quantity} shares of ${stockSymbol.toUpperCase()}`
+                    if(quantity > 1) {
+                        document.getElementById("stockQuote").innerText = `${convertToUsCurrency.format(fullPrice)} is the cost for ${quantity} shares of ${stockSymbol.toUpperCase()}`
+                    } else {
+                        document.getElementById("stockQuote").innerText = `${convertToUsCurrency.format(fullPrice)} is the cost for ${quantity} share of ${stockSymbol.toUpperCase()}`
+                    }
+                    
+                    
+                    
                     // transactionStockSymbol.value = stockSymbol
                     // transactionShares.value = quantity
                     // transactionPricePerShare.value = data


### PR DESCRIPTION
About to do the same logic on the back end when it loads the number of shares to display for the portfolio page