### PR TITLE
think I fixed authenticity error

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,7 +5,7 @@ class TransactionsController < ApplicationController
 
   # I seem to have set up the routing where there has been an issue twice with verifying the authenticy token and the app crashes. The following line of code:
 
-  skip_before_action :verify_authenticity_token
+  # skip_before_action :verify_authenticity_token
 
   # is supposed to fix the app from crashing, but as I understand this can put my app at risk for Cross-Site Request Forgery (CSRF) attacks.
   

--- a/app/views/holdings/index.html.erb
+++ b/app/views/holdings/index.html.erb
@@ -77,7 +77,7 @@
 <br>
 
 <div id="hiddenForms">
-<form action="/transactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="nhVaAbv4yLMu2ri6/6X8VUPrnGGvivrUdPLKfhxVB+UU+1RCFMbHj9H5r34JXV84C2mg/7iK3x/Yc42RCtJYng==">
+<form action="/transactions" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>"">
 
 
 
@@ -102,7 +102,7 @@
   </div>
 </form>
 
-<form action="/holdings" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="xMV/dJ+69GFfA13OoNqc9FXBmrYFVsX0rcuCd25NEuZOK3E3MIT7XaAgSgpWIj+ZHUOmKBJW4D8BSsWYeMpNnQ==">
+<form action="/holdings" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
 
  
 


### PR DESCRIPTION
For better understanding of what was going on I swapped out rails form helpers for the actual HTML code they generated. I accidentally grabbed the hard coded value of the authenticity token though.

I've now swapped that out for Rails' view helper "form_authenticity_token"

I think this will fix the issue, and therefore I've re-added Rails' built-in "verify_authenticity_token" validation. 